### PR TITLE
fixes login y register de terceros

### DIFF
--- a/src/Controllers/loginController/facebookRegisterController.js
+++ b/src/Controllers/loginController/facebookRegisterController.js
@@ -25,7 +25,6 @@ const facebookRegisterController = async (token, userId) => {
       await newUser.addRoles(1);
       var user = await User.findOne({
         where: { email },
-        attributes: ["name", "email", "picture"],
         include: {
           model: Role,
           attributes: ["id", "name"],

--- a/src/Controllers/loginController/googleRegisterController.js
+++ b/src/Controllers/loginController/googleRegisterController.js
@@ -24,7 +24,6 @@ const googleRegisterController = async (token) => {
       await newUser.addRoles(1);
       var user = await User.findOne({
         where: { email },
-        attributes: ["name", "email", "picture"],
         include: {
           model: Role,
           attributes: ["id", "name"],

--- a/src/Handlers/loginHandler/facebookLoginHandler.js
+++ b/src/Handlers/loginHandler/facebookLoginHandler.js
@@ -7,9 +7,9 @@ const facebookLogin = async (req, res) => {
   try {
     const user = await facebookLoginController(token, userId);
     if (!user) return res.status(401).send("Usuario no registrado");
-    const { name, email, picture } = user;
+    const { name, email, picture, id } = user;
 
-    const response = { name, email, picture, roles: user.Roles };
+    const response = { name, email, picture, roles: user.Roles, id };
     return res.status(201).json(response);
   } catch (error) {
     return res.status(500).send(error.message);

--- a/src/Handlers/loginHandler/facebookRegisterHandler.js
+++ b/src/Handlers/loginHandler/facebookRegisterHandler.js
@@ -12,6 +12,7 @@ const facebookRegister = async (req, res) => {
         email: newUser.email,
         picture: newUser.picture,
         roles: newUser.Roles,
+        id: newUser.id,
       };
       return res.status(201).json(response);
     } else {

--- a/src/Handlers/loginHandler/googleRegisterHandler.js
+++ b/src/Handlers/loginHandler/googleRegisterHandler.js
@@ -12,6 +12,7 @@ const googleRegister = async (req, res) => {
         email: newUser.email,
         picture: newUser.picture,
         roles: newUser.Roles,
+        id: newUser.id,
       };
       return res.status(201).json(response);
     } else {


### PR DESCRIPTION
Ahora las cuatro rutas (login y registro de fb y google) devuelven la misma informacion